### PR TITLE
Use DHCP options to set static routes for client

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -7,6 +7,10 @@ max-lease-time 7200;
 authoritative;
 log-facility local7;
 
+# describe the codes used for injecting static routes
+option classless-routes code 121 = array of unsigned integer 8;
+option classless-routes-win code 249 = array of unsigned integer 8;
+
 # A netmask of 128 will work across all platforms
 # A way to cover /0 is to use a short lease.
 # As soon as the lease expires and client sends a
@@ -19,4 +23,8 @@ subnet 0.0.0.0 netmask 128.0.0.0 {
 	max-lease-time 7200;
 	option domain-name "local";
 	option domain-name-servers 1.0.0.1;
+# send the routes for both the top and bottom of the IPv4 address space	
+        option classless-routes 1,0, 1,0,0,1,  1,128, 1,0,0,1;
+        option classless-routes-win 1,0, 1,0,0,1,  1,128, 1,0,0,1;
+	
 }


### PR DESCRIPTION
DHCP options 121 & 249 allow the DHCP to send static routes to the client.
Confirmed on Windows 8.1 Enterprise